### PR TITLE
Ntilda imag as output

### DIFF
--- a/src/fieldws.f
+++ b/src/fieldws.f
@@ -5113,7 +5113,11 @@ c      end do
       write(245, 3412) ((spx(i,j), spy(i,j), spz(i,j), 
      .                                    i = 1, nnodex), j = 1, nnodey)     
       
-      close (245)      
+      write(140, 3970)
+ 3970 format('SCALARS ntilda_e_imag float 1')
+      write(140, 2849)
+      write (140, 3411) ((fimag(i,j), i = 1, nnodex), j = 1, nnodey)
+      close (245)
                                                
 
  5000 continue

--- a/src/fieldws.f
+++ b/src/fieldws.f
@@ -4992,6 +4992,10 @@ c      end do
       write(140, 2849)        
       write (140, 3411) ((freal(i,j), i = 1, nnodex), j = 1, nnodey)        
             
+      write(140, 3970)
+ 3970 format('SCALARS ntilda_e_imag float 1')
+      write(140, 2849)
+      write (140, 3411) ((fimag(i,j), i = 1, nnodex), j = 1, nnodey)
 
       write(140, 3960)
  3960 format('SCALARS divq float 1')        
@@ -5113,10 +5117,6 @@ c      end do
       write(245, 3412) ((spx(i,j), spy(i,j), spz(i,j), 
      .                                    i = 1, nnodex), j = 1, nnodey)     
       
-      write(140, 3970)
- 3970 format('SCALARS ntilda_e_imag float 1')
-      write(140, 2849)
-      write (140, 3411) ((fimag(i,j), i = 1, nnodex), j = 1, nnodey)
       close (245)
                                                
 


### PR DESCRIPTION
Added `ntilda_e_imag` to the output of Efield_2D.vtk.